### PR TITLE
Fix docker support in 32-bit mode

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -1025,6 +1025,10 @@ config SYSVIPC_COMPAT
 	def_bool y
 	depends on COMPAT && SYSVIPC
 
+config KEYS_COMPAT
+	def_bool y
+	depends on COMPAT && KEYS
+
 endmenu
 
 menu "Power management options"


### PR DESCRIPTION
This PR fixes a missing `CONFIG_KEYS_COMPAT` when building 64-bit kernel to get docker to work on 32-bit userland.

Thanks @Raybuntu