### PR TITLE
Fix compile error 8723bs

### DIFF
--- a/drivers/net/wireless/rockchip_wlan/rtl8723bs/hal/hal_mp.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8723bs/hal/hal_mp.c
@@ -984,7 +984,7 @@ void mpt_SetRFPath_8723B(PADAPTER pAdapter)
 	}
 
 	switch (pAdapter->mppriv.antenna_tx) {
-		u8 p = 0, i = 0;
+		u8 p, i;
 	case ANTENNA_A: /*/ Actually path S1  (Wi-Fi)*/
 			{
 			pMptCtx->MptRfPath = ODM_RF_PATH_A;			


### PR DESCRIPTION
The 8723bs driver has variable initialization all through its switch-case statements, breaking compile with gcc 7+

This only fixes the specific build failure for the 8723bs, the rest of the problem code exists.  Probably also of interest to @jamess-huang.