### PR TITLE
ayufan: rockchip-spi fails when high_speed pinctrl is missing

### DIFF
--- a/drivers/spi/spi-rockchip.c
+++ b/drivers/spi/spi-rockchip.c
@@ -777,10 +777,10 @@ static int rockchip_spi_probe(struct platform_device *pdev)
 
 	rs->high_speed_state = pinctrl_lookup_state(rs->dev->pins->p,
 						     "high_speed");
-	if (IS_ERR_OR_NULL(rs->high_speed_state))
+	if (IS_ERR_OR_NULL(rs->high_speed_state)) {
 		dev_warn(&pdev->dev, "no high_speed pinctrl state\n");
-	else
 		rs->high_speed_state = NULL;
+	}
 
 	ret = devm_spi_register_master(&pdev->dev, master);
 	if (ret) {


### PR DESCRIPTION
Fixes kernel crash when `highspeed` interface is not defined:

```text
[    1.641858] lkdtm: No crash points registered, enable through debugfs
[    1.644632] rockchip-spi ff190000.spi: no high_speed pinctrl state
[    1.646337] Unable to handle kernel NULL pointer dereference at virtual address 00000005
[    1.647412] pgd = ffffff80093b9000
[    1.647873] [00000005] *pgd=00000000feffe003, *pud=00000000feffe003, *pmd=0000000000000000
[    1.649019] Internal error: Oops: 96000005 [#1] SMP
[    1.649643] Modules linked in:
[    1.650065] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 4.4.120-rockchip-ayufan-195 #1
[    1.651042] Hardware name: Pine64 Rock64 (DT)
[    1.651603] task: ffffffc0f5d48000 task.stack: ffffffc0f5d44000
[    1.652366] PC is at pinctrl_select_state+0x3c/0x12c
[    1.653004] LR is at pinctrl_select_state+0x7c/0x12c
[    1.653641] pc : [<ffffff8008596840>] lr : [<ffffff8008596880>] pstate: 60000045
[    1.654574] sp : ffffffc0f5d47420
```