### PR TITLE
power: cw2015_battery: add sysfs attribute charge_full_design

### DIFF
--- a/drivers/power/cw2015_battery.c
+++ b/drivers/power/cw2015_battery.c
@@ -651,6 +651,7 @@ static int cw_battery_get_property(struct power_supply *psy,
 		break;
 
 	case POWER_SUPPLY_PROP_CHARGE_FULL:
+	case POWER_SUPPLY_PROP_CHARGE_FULL_DESIGN:
 		val->intval = cw_bat->plat_data.design_capacity * 1000;
 		break;
 
@@ -674,6 +675,7 @@ static enum power_supply_property cw_battery_properties[] = {
 	POWER_SUPPLY_PROP_TECHNOLOGY,
 	POWER_SUPPLY_PROP_CHARGE_COUNTER,
 	POWER_SUPPLY_PROP_CHARGE_FULL,
+	POWER_SUPPLY_PROP_CHARGE_FULL_DESIGN,
 	POWER_SUPPLY_PROP_TEMP,
 };
 


### PR DESCRIPTION
Make cw2015_battery driver export sysfs attribute charge_full_design.
For now, its value is set to the same value as charge_full.

Userspace program upowerd permanently logs warnings if this
attribute is not set.

Signed-off-by: Stefan Schaeckeler <schaecsn@gmx.net>