### PR TITLE
headset_observe: Fix system resume with headset insert could not sche…

### DIFF
--- a/drivers/headset_observe/rk_headset_irq_hook_adc.c
+++ b/drivers/headset_observe/rk_headset_irq_hook_adc.c
@@ -328,7 +328,7 @@ static void hook_once_work(struct work_struct *work)
 	else if(val >= HOOK_LEVEL_HIGH)
 	{
 		headset_info->isMic = 1;//have mic
-		schedule_delayed_work(&headset_info->hook_work,msecs_to_jiffies(100));
+		schedule_delayed_work(&headset_info->hook_work,msecs_to_jiffies(HOOK_ADC_SAMPLE_TIME));
 	}
 
 	headset_info->cur_headset_status = headset_info->isMic ? BIT_HEADSET:BIT_HEADSET_NO_MIC;
@@ -454,7 +454,7 @@ static void hook_work_callback(struct work_struct *work)
 		input_sync(headset->input_dev);
 	}	
 status_error:
-	 schedule_delayed_work(&headset_info->hook_work,msecs_to_jiffies(100));
+	 schedule_delayed_work(&headset_info->hook_work,msecs_to_jiffies(HOOK_ADC_SAMPLE_TIME));
 out:;
 }
 
@@ -574,7 +574,9 @@ int rk_headset_adc_resume(struct platform_device *pdev)
 	DBG("%s----%d\n",__FUNCTION__,__LINE__);	
 //	enable_irq(headset_info->irq[HEADSET]);
 //	if(headset_info->isMic)
-//		mod_timer(&headset_info->hook_timer, jiffies + msecs_to_jiffies(1500));	
+//		mod_timer(&headset_info->hook_timer, jiffies + msecs_to_jiffies(1500));
+	if(headset_info->headset_status = HEADSET_IN)
+		schedule_delayed_work(&headset_info->hook_work, msecs_to_jiffies(HOOK_ADC_SAMPLE_TIME));
 	return 0;
 }
 


### PR DESCRIPTION
…dule delayed work

On my test:
	platform:rk3326
	step by step:
	1.poweron
	2.evtest /dev/input/event3 # because on my board event3 is headset input event node
	3.test press & release button on headset
	4.evtest could output EV_KEY & code value and other infos
	5.echo mem > /sys/power/state # make board system suspend
	6.press power button to make board resume
	7.retry 3th step
	8.evtest couldn.t output anything, but replug headset could make evtest output back
	  to normal.
Therefore:
	add judge headset state when system resume after suspend

Change-Id: I58ddeaaccbb3471b46ff29dc0680d8ab58afcb0b
Signed-off-by: evan <tianyu_0105@163.com>