### PR TITLE
kernel: driver: rk628 fix clk disable when probe success

### DIFF
--- a/drivers/media/i2c/rk628/rk628_csi_v4l2.c
+++ b/drivers/media/i2c/rk628/rk628_csi_v4l2.c
@@ -2160,7 +2160,9 @@ free_endpoint:
 put_node:
 	of_node_put(ep);
 clk_put:
-	clk_disable_unprepare(csi->soc_24M);
+	if (ret != 0) {
+		clk_disable_unprepare(csi->soc_24M);
+	}
 
 	return ret;
 }
@@ -2475,6 +2477,7 @@ static int rk628_csi_remove(struct i2c_client *client)
 	rk628_control_assert(csi->rk628, RGU_VOP);
 	rk628_control_assert(csi->rk628, RGU_CSI);
 
+	clk_disable_unprepare(csi->soc_24M);
 	return 0;
 }
 


### PR DESCRIPTION
Fix #322 
    In rk628_csi_probe_of function, when we got success in probe, the ret value is 0, but the clk_disable_unprepare(csi->soc_24M) still will be invoked. This will cause the enable_count of soc_24M minus 1.
    So if there is no other driver use soc_24M, the clock will be disable, and the the i2c comunication will be failed.