### PR TITLE
usb: gadget: fix: android_device_create

### DIFF
--- a/drivers/usb/gadget/configfs.c
+++ b/drivers/usb/gadget/configfs.c
@@ -1776,9 +1776,11 @@ static int android_device_create(struct gadget_info *gi)
 	struct device_attribute **attrs;
 	struct device_attribute *attr;
 
+	dev_t devt = MKDEV(0, gadget_index);
+
 	INIT_WORK(&gi->work, android_work);
 	gi->dev = device_create(android_class, NULL,
-			MKDEV(0, 0), NULL, "android%d", gadget_index++);
+			devt, NULL, "android%d", gadget_index++);
 	if (IS_ERR(gi->dev))
 		return PTR_ERR(gi->dev);
 


### PR DESCRIPTION
Fixed uninstallation failure caused by creating multiple devices in android_device_create with the same device number